### PR TITLE
design : 뒤로가기 헤더 내 타이틀 추가할 수 있도록 변경

### DIFF
--- a/src/app/signup/profile/image-select/page.tsx
+++ b/src/app/signup/profile/image-select/page.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import React from 'react';
+import { useRouter } from 'next/navigation';
+import BackHeader from '@/components/molecules/BackHeader';
+
+const ProfileImageSelectPage: React.FC = () => {
+  const router = useRouter();
+
+  const handleBack = () => {
+    router.back();
+  };
+
+  return (
+    <div className="flex flex-col max-w-sm mx-auto px-6 pt-25 pb-[env(safe-area-inset-bottom)]">
+      <BackHeader onBack={handleBack} title={'이미지 선택'} />
+      <div>이미지 선택 페이지</div>
+    </div>
+  );
+};
+
+export default ProfileImageSelectPage;

--- a/src/components/molecules/BackHeader.tsx
+++ b/src/components/molecules/BackHeader.tsx
@@ -3,11 +3,13 @@ import BackButton from '@/components/atoms/BackButton';
 
 interface BackHeaderProps {
   onBack?: () => void;
+  title?: string;
 }
 
-const BackHeader: React.FC<BackHeaderProps> = ({ onBack }) => (
+const BackHeader: React.FC<BackHeaderProps> = ({ onBack, title }) => (
   <header className="fixed top-0 left-0 w-full z-50 bg-white h-12 flex items-center px-4 my-3">
     <BackButton onClick={onBack} />
+    {title && <span className="ml-3 title3">{title}</span>}
   </header>
 );
 

--- a/src/components/templates/ProfileScreen.tsx
+++ b/src/components/templates/ProfileScreen.tsx
@@ -25,7 +25,11 @@ const ProfileScreen = () => {
       <div className="flex-1 overflow-y-auto">
         <div className="title1 my-10 text-center">프로필을 완성해주세요!</div>
         <div className="flex justify-center mb-20">
-          <ProfileImageWithButton />
+          <ProfileImageWithButton
+            onButtonClick={() => {
+              router.push('/signup/profile/image-select');
+            }}
+          />
         </div>
 
         <NicknameCheckForm onVerify={setIsNicknameVerified} />


### PR DESCRIPTION

## 📖 PR 제목

design : 뒤로가기 헤더 내 타이틀 추가할 수 있도록 변경

---

## 📝 변경 사항

- 뒤로가기 헤더 내 타이틀 추가할 수 있도록 변경(타이틀은 선택 사항)
- 프로필 이미지 선택 페이지 추가

---

## ✅ 체크리스트

- [x] 코드 스타일 가이드(ESLint/Prettier) 준수
- [x] 기능 동작 테스트 완료
- [x] 관련 문서(README, 이슈)에 반영

---

## 📸 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/ed815d97-6639-4e39-8440-7ff8bcd78346)