### PR TITLE
design(#25) : 프로필 이미지 선택 페이지 퍼블리싱

### DIFF
--- a/src/app/signup/profile/image-select/components/ProfileImageButton.tsx
+++ b/src/app/signup/profile/image-select/components/ProfileImageButton.tsx
@@ -1,0 +1,24 @@
+import { Button } from '@heroui/react';
+import Image from 'next/image';
+
+interface ProfileImageButtonProps {
+  src: string;
+  selected: boolean;
+  onSelect: (src: string) => void;
+}
+
+const ProfileImageButton: React.FC<ProfileImageButtonProps> = ({ src, selected, onSelect }) => (
+  <Button
+    isIconOnly
+    variant={selected ? 'solid' : 'ghost'}
+    color={selected ? 'primary' : 'default'}
+    className={`relative aspect-square rounded-[8px] overflow-hidden focus:ring-2 focus:ring-brand-primary ${
+      selected ? 'ring-2 ring-brand-primary' : ''
+    }`}
+    onPress={() => onSelect(src)}
+  >
+    <Image src={src} alt="프로필" fill style={{ objectFit: 'cover' }} />
+  </Button>
+);
+
+export default ProfileImageButton;

--- a/src/app/signup/profile/image-select/components/ProfileImageGrid.tsx
+++ b/src/app/signup/profile/image-select/components/ProfileImageGrid.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import ProfileImageButton from './ProfileImageButton';
+import UploadImageButton from './UploadImageButton';
+
+interface ProfileImageGridProps {
+  images: string[];
+  selectedImage: string | null;
+  onSelect: (src: string) => void;
+  onUploadClick: () => void;
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
+  onFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+const ProfileImageGrid: React.FC<ProfileImageGridProps> = ({
+  images,
+  selectedImage,
+  onSelect,
+  onUploadClick,
+  fileInputRef,
+  onFileChange,
+}) => (
+  <div className="grid grid-cols-3 gap-4 mb-6">
+    {images.map((src, idx) => (
+      <ProfileImageButton
+        key={src + idx}
+        src={src}
+        selected={selectedImage === src}
+        onSelect={onSelect}
+      />
+    ))}
+    <UploadImageButton
+      onClick={onUploadClick}
+      fileInputRef={fileInputRef}
+      onFileChange={onFileChange}
+    />
+  </div>
+);
+
+export default ProfileImageGrid;

--- a/src/app/signup/profile/image-select/components/UploadImageButton.tsx
+++ b/src/app/signup/profile/image-select/components/UploadImageButton.tsx
@@ -1,0 +1,34 @@
+import { Button } from '@heroui/react';
+import React from 'react';
+
+interface UploadImageButtonProps {
+  onClick: () => void;
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
+  onFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+const UploadImageButton: React.FC<UploadImageButtonProps> = ({
+  onClick,
+  fileInputRef,
+  onFileChange,
+}) => (
+  <Button
+    isIconOnly
+    radius="lg"
+    className="relative aspect-square rounded-[8px] overflow-hidden bg-neutral-500"
+    onPress={onClick}
+    aria-label="내 사진 업로드"
+  >
+    <span className="text-3xl font-bold text-neutral-0">+</span>
+    <input
+      type="file"
+      accept="image/jpeg,image/png,image/webp"
+      ref={fileInputRef}
+      className="hidden"
+      onChange={onFileChange}
+      tabIndex={-1}
+    />
+  </Button>
+);
+
+export default UploadImageButton;

--- a/src/app/signup/profile/image-select/page.tsx
+++ b/src/app/signup/profile/image-select/page.tsx
@@ -1,20 +1,89 @@
 'use client';
 
-import React from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import BackHeader from '@/components/molecules/BackHeader';
+import NextButton from '@/components/atoms/Button';
+import ProfileImageGrid from './components/ProfileImageGrid';
+
+const DEFAULT_IMAGES = ['/icons/kakao.svg', '/icons/naver.svg'];
 
 const ProfileImageSelectPage: React.FC = () => {
   const router = useRouter();
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const handleBack = () => {
-    router.back();
+  const [customImages, setCustomImages] = useState<string[]>([]);
+  const [selectedImage, setSelectedImage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const storedImage = localStorage.getItem('profileImage');
+      if (storedImage) {
+        if (!DEFAULT_IMAGES.includes(storedImage)) {
+          setCustomImages([storedImage]);
+        } else {
+          setCustomImages([]);
+        }
+        setSelectedImage(storedImage);
+      }
+    }
+  }, []);
+
+  const handleSelect = (src: string) => setSelectedImage(src);
+
+  const handleUpload = (file: File) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      if (typeof e.target?.result === 'string') {
+        setCustomImages((prev) => [...prev, e.target!.result as string]);
+        setSelectedImage(e.target.result as string);
+      }
+    };
+    reader.readAsDataURL(file);
   };
 
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files[0]) {
+      handleUpload(e.target.files[0]);
+    }
+  };
+
+  const handleNext = () => {
+    if (selectedImage) {
+      localStorage.setItem('profileImage', selectedImage);
+      router.back();
+    }
+  };
+
+  const allImages = [...DEFAULT_IMAGES, ...customImages];
+
   return (
-    <div className="flex flex-col max-w-sm mx-auto px-6 pt-25 pb-[env(safe-area-inset-bottom)]">
-      <BackHeader onBack={handleBack} title={'이미지 선택'} />
-      <div>이미지 선택 페이지</div>
+    <div className="flex flex-col max-w-sm mx-auto px-6 pt-25 pb-[env(safe-area-inset-bottom)] min-h-screen">
+      <BackHeader onBack={() => router.back()} title="이미지 선택" />
+
+      <div className="mt-1 flex-1">
+        <div className="mb-4 labelL">프로필 이미지</div>
+        <ProfileImageGrid
+          images={allImages}
+          selectedImage={selectedImage}
+          onSelect={handleSelect}
+          onUploadClick={() => fileInputRef.current?.click()}
+          fileInputRef={fileInputRef}
+          onFileChange={handleFileChange}
+        />
+      </div>
+
+      <div className="fixed bottom-8 left-0 w-full bg-white z-50 px-6 pb-[env(safe-area-inset-bottom)]">
+        <div className="max-w-sm mx-auto flex justify-center">
+          <NextButton
+            onClick={handleNext}
+            disabled={!selectedImage}
+            variant={selectedImage ? 'primary' : 'secondary'}
+          >
+            다음
+          </NextButton>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/components/templates/ProfileScreen.tsx
+++ b/src/components/templates/ProfileScreen.tsx
@@ -1,15 +1,30 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Button from '@/components/atoms/Button';
 import StepDots from '../molecules/StepDots';
 import { useRouter } from 'next/navigation';
 import NicknameCheckForm from '../organisms/NicknameCheckForm';
 import ProfileImageWithButton from '../molecules/ProfileImageWithButton';
 import BackHeader from '../molecules/BackHeader';
+
+const DEFAULT_PROFILE_IMAGE = '/icons/profile-default.svg';
+
 const ProfileScreen = () => {
   const [isNicknameVerified, setIsNicknameVerified] = useState(false);
+  const [profileImage, setProfileImage] = useState<string>(DEFAULT_PROFILE_IMAGE);
   const router = useRouter();
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const storedImage = localStorage.getItem('profileImage');
+      if (storedImage) {
+        setProfileImage(storedImage);
+      } else {
+        setProfileImage(DEFAULT_PROFILE_IMAGE);
+      }
+    }
+  }, []);
 
   const handleBack = () => {
     router.back();
@@ -26,6 +41,7 @@ const ProfileScreen = () => {
         <div className="title1 my-10 text-center">프로필을 완성해주세요!</div>
         <div className="flex justify-center mb-20">
           <ProfileImageWithButton
+            src={profileImage}
             onButtonClick={() => {
               router.push('/signup/profile/image-select');
             }}


### PR DESCRIPTION
## 📖 PR 제목

design(#25) : 프로필 이미지 선택 페이지 퍼블리싱

---

## 📝 변경 사항

- 기존 프로필 입력 창에서 카메라 아이콘 누르면 이미지 선택 페이지 열리도록 수정
- 기본 이미지 목록 및 사용자가 업로드한 이미지(jpg, png, webp) 목록 보여주기
- 이미지 선택되면 기존 프로필 창으로 돌아가기
- 기본 이미지 목록은 수정 필요
- closes #25 

---

## ✅ 체크리스트

- [x] 코드 스타일 가이드(ESLint/Prettier) 준수
- [x] 기능 동작 테스트 완료
- [x] 관련 문서(README, 이슈)에 반영

---

## 📸 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/b48f3df1-111a-4f82-963a-7645dcbcc90a)
![image](https://github.com/user-attachments/assets/65899231-7af8-44ce-9097-132095d34a02)
![image](https://github.com/user-attachments/assets/c5f18cfa-57ac-4a5b-b361-296a00264690)
![image](https://github.com/user-attachments/assets/1ec41340-fbe3-4fb6-a5dd-9cf450721885)
