### PR TITLE
feat(#40) : 닉네임 중복확인 API 연결

### DIFF
--- a/src/components/organisms/NicknameCheckForm.tsx
+++ b/src/components/organisms/NicknameCheckForm.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import NicknameInputWithButton from '../molecules/NicknameInputWithButton';
 import ValidationMessages from '../molecules/ValidationMessages';
 import { getNicknameValidationErrors } from '@/utils/nicknameValidation';
+import { SWAGGER_API_URL } from '@/constants/api';
 
 interface NicknameCheckFormProps {
   onVerify?: (verified: boolean) => void;
@@ -82,21 +83,29 @@ const NicknameCheckForm: React.FC<NicknameCheckFormProps> = ({ onVerify }) => {
   );
 };
 
-// 임시 API
-async function checkNicknameAPI(nickname: string): Promise<boolean> {
-  await new Promise((r) => setTimeout(r, 700));
-  return nickname !== 'taken'; // 'taken'만 중복 처리
-}
-
+// // 임시 API
 // async function checkNicknameAPI(nickname: string): Promise<boolean> {
-//   const response = await fetch(`${API_URL}/nickname/check`, {
-//     method: 'POST',
-//     headers: { 'Content-Type': 'application/json' },
-//     body: JSON.stringify({ nickname }),
-//   });
-//   if (!response.ok) throw new Error('API 오류');
-//   const data = await response.json();
-//   return data.available;
+//   await new Promise((r) => setTimeout(r, 700));
+//   return nickname !== 'taken'; // 'taken'만 중복 처리
 // }
+
+async function checkNicknameAPI(nickname: string): Promise<boolean> {
+  const url = new URL(`${SWAGGER_API_URL}/members/nickname/available`);
+  url.searchParams.append('nickname', nickname);
+
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  const data = await response.json();
+
+  if (response.ok && data.code === '200') {
+    return data.data === true;
+  } else {
+    console.error('API 오류:', data.message, data.data);
+    throw new Error(data.message || 'API 요청 에러');
+  }
+}
 
 export default NicknameCheckForm;

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,1 +1,2 @@
 export const API_URL = process.env.NEXT_PUBLIC_API_URL!;
+export const SWAGGER_API_URL = process.env.NEXT_PUBLIC_SWAGGER_API_URL!;


### PR DESCRIPTION
<!-- 제목은 한 줄로 간결하게 작성해주세요. -->

## 📖 PR 제목

닉네임 중복확인 API 연결

---

## 📝 변경 사항

- 닉네임 중복확인 API 연결 진행
- Swagger 주소 환경변수에 추가
- 오류 백엔드와 함께 점검 필요함
- 임시 API 주석처리한 코드 추후 삭제 필요함
- closes #40 

---

## ✅ 체크리스트

- [x] 코드 스타일 가이드(ESLint/Prettier) 준수
- [x] 기능 동작 테스트 완료
- [x] 관련 문서(README, 이슈)에 반영

---

## 📸 스크린샷 (선택)

<변경 UI가 있다면 캡처 첨부>
